### PR TITLE
Feat: Check for Ollama models on startup

### DIFF
--- a/desktop_ai/core/config.py
+++ b/desktop_ai/core/config.py
@@ -1,7 +1,7 @@
 """Simple configuration management."""
 import json
-from typing import Dict, Any
-from .constants import CONFIG_FILE, DEFAULT_MODEL, SYSTEM_INSTRUCTIONS
+from typing import Dict, Any, Optional
+from .constants import CONFIG_FILE, SYSTEM_INSTRUCTIONS
 
 
 class Config:
@@ -13,7 +13,7 @@ class Config:
     def _load_config(self) -> Dict[str, Any]:
         """Load configuration from file."""
         defaults = {
-            "model": DEFAULT_MODEL,
+            "model": None,
             "system_prompt": SYSTEM_INSTRUCTIONS
         }
         
@@ -36,8 +36,8 @@ class Config:
             pass  # Silently ignore save errors
     
     @property
-    def model(self) -> str:
-        return self._config.get('model', DEFAULT_MODEL)
+    def model(self) -> Optional[str]:
+        return self._config.get('model')
     
     @model.setter
     def model(self, value: str) -> None:

--- a/desktop_ai/core/constants.py
+++ b/desktop_ai/core/constants.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 # Models and API
-DEFAULT_MODEL = "gpt-oss:20b"
 OLLAMA_BASE_URL = "http://localhost:11434/v1"
 API_KEY = "sk-fake_api_key"
 SYSTEM_INSTRUCTIONS = "You are a helpful assistant"

--- a/desktop_ai/main.py
+++ b/desktop_ai/main.py
@@ -1,13 +1,35 @@
 import sys
+from PyQt6.QtWidgets import QApplication, QMessageBox
 from .ui import DesktopAI
+from .services import OllamaService
+from .core import config
 
 
 def main():
     """Main entry point with error handling."""
+    app = QApplication(sys.argv)
+
     try:
-        app = DesktopAI(sys.argv)
-        app.run()
-    except Exception as e:
+        models = OllamaService.get_models()
+        if not models:
+            QMessageBox.critical(
+                None,
+                "No Ollama Models Found",
+                "No Ollama models were found. Please install a model to continue.",
+            )
+            sys.exit(1)
+
+        if not config.model:
+            config.model = models[0]
+
+        desktop_ai = DesktopAI(app)
+        desktop_ai.run()
+    except Exception:
+        QMessageBox.critical(
+            None,
+            "Application Error",
+            "An unexpected error occurred. Please check the logs.",
+        )
         sys.exit(1)
 
 

--- a/desktop_ai/services/ollama_service.py
+++ b/desktop_ai/services/ollama_service.py
@@ -1,5 +1,6 @@
 """Simplified Ollama service."""
 import ollama
+import logging
 from typing import List
 
 
@@ -12,14 +13,12 @@ class OllamaService:
         try:
             response = ollama.list()
             models = []
-            if hasattr(response, 'models') and response.models:
-                for model in response.models:
-                    if hasattr(model, 'model'):
-                        models.append(model.model)
-                    elif isinstance(model, dict) and 'model' in model:
-                        models.append(model['model'])
+            if "models" in response:
+                for model_info in response["models"]:
+                    models.append(model_info["name"])
             return sorted(models)
-        except Exception:
+        except Exception as e:
+            logging.error(f"Error getting Ollama models: {e}")
             return []
     
     @staticmethod
@@ -28,5 +27,6 @@ class OllamaService:
         try:
             ollama.list()
             return True
-        except Exception:
+        except Exception as e:
+            logging.error(f"Error checking Ollama availability: {e}")
             return False

--- a/desktop_ai/services/ollama_service.py
+++ b/desktop_ai/services/ollama_service.py
@@ -6,21 +6,21 @@ from typing import List
 
 class OllamaService:
     """Service for Ollama model management."""
-    
+
     @staticmethod
     def get_models() -> List[str]:
         """Get available models."""
         try:
             response = ollama.list()
             models = []
-            if "models" in response:
-                for model_info in response["models"]:
-                    models.append(model_info["name"])
+            if hasattr(response, 'models') and response.models:
+                for model_info in response.models:
+                    models.append(model_info.model)
             return sorted(models)
         except Exception as e:
             logging.error(f"Error getting Ollama models: {e}")
             return []
-    
+
     @staticmethod
     def is_available() -> bool:
         """Check if Ollama is available."""

--- a/desktop_ai/ui/app.py
+++ b/desktop_ai/ui/app.py
@@ -6,12 +6,12 @@ from PyQt6.QtGui import QAction
 from .windows import MainWindow, SettingsWindow
 
 
-class DesktopAI(QApplication):
+class DesktopAI:
     """Main application with system tray support."""
 
-    def __init__(self, argv):
-        super().__init__(argv)
-        self.setQuitOnLastWindowClosed(False)
+    def __init__(self, app: QApplication):
+        self.app = app
+        self.app.setQuitOnLastWindowClosed(False)
 
         # Check if system tray is available
         if not QSystemTrayIcon.isSystemTrayAvailable():
@@ -26,10 +26,10 @@ class DesktopAI(QApplication):
 
     def _setup_system_tray(self):
         """Setup system tray icon and menu."""
-        self.tray_icon = QSystemTrayIcon(self)
+        self.tray_icon = QSystemTrayIcon()
 
         # Set icon
-        style = self.style()
+        style = self.app.style()
         if style:
             icon = style.standardIcon(QStyle.StandardPixmap.SP_MessageBoxQuestion)
             self.tray_icon.setIcon(icon)
@@ -47,20 +47,20 @@ class DesktopAI(QApplication):
 
     def _setup_tray_menu(self):
         """Setup system tray menu."""
-        menu = QMenu()
+        menu = QMenu(self.main_window)
 
-        show_action = QAction("Show", self)
+        show_action = QAction("Show", self.main_window)
         show_action.triggered.connect(self._show_window)
         menu.addAction(show_action)
 
-        settings_action = QAction("Settings", self)
+        settings_action = QAction("Settings", self.main_window)
         settings_action.triggered.connect(self._show_settings)
         menu.addAction(settings_action)
 
         menu.addSeparator()
 
-        exit_action = QAction("Exit", self)
-        exit_action.triggered.connect(self.quit)
+        exit_action = QAction("Exit", self.main_window)
+        exit_action.triggered.connect(self.app.quit)
         menu.addAction(exit_action)
 
         self.tray_icon.setContextMenu(menu)
@@ -95,4 +95,4 @@ class DesktopAI(QApplication):
 
     def run(self):
         """Run the application."""
-        sys.exit(self.exec())
+        sys.exit(self.app.exec())


### PR DESCRIPTION
This commit introduces a startup check to ensure that Ollama has at least one model installed before launching the application.

Key changes:
- Removed the hardcoded default model 'gpt-oss:20b'.
- The application now checks for available Ollama models on startup.
- If no models are found, a warning message is displayed, and the application exits.
- If models are found and no model is configured, the first available model is set as the default.
- Refactored the main application class to improve its structure and avoid issues with multiple QApplication instances.
- Improved error handling in the Ollama service.